### PR TITLE
Timeline: restore `Item#message` height shrink ability

### DIFF
--- a/client/qml/TimelineItem.qml
+++ b/client/qml/TimelineItem.qml
@@ -331,27 +331,20 @@ Item {
 
                 TimelineMouseArea {
                     anchors.fill: parent
-                    acceptedButtons: Qt.MiddleButton
-
-                    onClicked: {
-                        if (textFieldImpl.hoveredLink)
-                            controller.resourceRequested(
-                                textFieldImpl.hoveredLink)
-                    }
-                }
-
-                TimelineMouseArea {
-                    anchors.fill: parent
-                    acceptedButtons: Qt.RightButton
-                    onClicked: controller.showMenu(index,
-                        textFieldImpl.hoveredLink, showingDetails)
-                }
-
-                TimelineMouseArea {
-                    anchors.fill: parent
                     cursorShape: textFieldImpl.hoveredLink
                                  ? Qt.PointingHandCursor : Qt.IBeamCursor
-                    acceptedButtons: Qt.NoButton
+                    acceptedButtons: Qt.MiddleButton | Qt.RightButton
+
+                    onClicked: {
+                        if (mouse.button === Qt.MiddleButton) {
+                            if (textFieldImpl.hoveredLink)
+                                controller.resourceRequested(
+                                    textFieldImpl.hoveredLink)
+                        } else if (mouse.button === Qt.RightButton) {
+                            controller.showMenu(index,
+                                textFieldImpl.hoveredLink, showingDetails)
+                        }
+                    }
 
                     onWheel: {
                         if (wheel.angleDelta.x != 0 &&

--- a/client/qml/TimelineItem.qml
+++ b/client/qml/TimelineItem.qml
@@ -118,24 +118,24 @@ Item {
         }
     }
 
+    TimelineMouseArea {
+        anchors.fill: fullMessage
+        acceptedButtons: Qt.AllButtons
+    }
+
     Column {
         id: fullMessage
         width: parent.width
 
         Rectangle {
             width: parent.width
-            height: sectionLabel.height + 2
+            height: childrenRect.height + 2
             visible: sectionVisible
             color: defaultPalette.window
             Label {
-                id: sectionLabel
                 font.bold: true
                 renderType: settings.render_type
                 text: section
-            }
-            TimelineMouseArea {
-                anchors.fill: parent
-                acceptedButtons: Qt.AllButtons
             }
         }
         Loader {
@@ -147,22 +147,12 @@ Item {
             width: parent.width
 
             sourceComponent: detailsArea
-
-            TimelineMouseArea {
-                anchors.fill: parent
-                acceptedButtons: Qt.AllButtons
-            }
         }
 
         Item {
             id: message
             width: parent.width
             height: childrenRect.height
-
-            TimelineMouseArea {
-                anchors.fill: parent
-                acceptedButtons: Qt.AllButtons
-            }
 
             // There are several layout styles (av - author avatar,
             // al - author label, ts - timestamp, c - content


### PR DESCRIPTION
This got broken by dbda393 which introduced circular dependency on height: `Item#message` height was dependent on `childrenRect.height` but it included a `MouseArea` which was dependent on `parent.height`.

It turned out by 87b18d9 via changing `discardButton` type from `ActiveLabel` to `ToolButton` which is taller and forces sent messages to shrink when it gets invisible (in normal circumstances, shortly after it appears).