### PR TITLE
Support custom chatting font

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ Settings not exposed in UI:
   By default it's `> \\1\n`.
 - `UI/quote_regex` - set to `^([\\s\\S]*)` to add `UI/quote_style` only at
   the beginning and end of the quote. By default it's `(.+)(?:\n|$)`.
+- `UI/Timeline/font_family` - font family (for example `Monospace`) to
+  display messages in the timeline.
+- `UI/Timeline/font_pointSize` - font size to display messages in the
+  timeline.
 
 Since version 0.0.9.4, AppImage binaries for Linux and .dmg files for macOS
 are compiled with Qt Keychain support. It means that Quaternion will try

--- a/client/qml/TimelineItem.qml
+++ b/client/qml/TimelineItem.qml
@@ -22,6 +22,8 @@ Item {
         readonly property string timeline_style: value("UI/timeline_style", "")
         readonly property bool show_author_avatars:
             value("UI/show_author_avatars", timeline_style != "xchat")
+        readonly property string font_family: value("UI/Timeline/font_family", "")
+        readonly property string font_pointSize: value("UI/Timeline/font_pointSize", 0)
     }
 
     // Property interface
@@ -195,6 +197,8 @@ Item {
 
                 color: authorColor
                 textFormat: Label.PlainText
+                font.family: settings.font_family ? settings.font_family : textFieldImpl.font.family
+                font.pointSize: settings.font_pointSize > 0 ? settings.font_pointSize : textFieldImpl.font.pointSize
                 font.bold: !xchatStyle
                 renderType: settings.render_type
 
@@ -223,18 +227,15 @@ Item {
             Label {
                 id: timelabel
                 anchors.top: xchatStyle ? authorAvatar.top : authorAvatar.bottom
-                anchors.topMargin: 1
-                anchors.bottomMargin: 1
                 anchors.left: parent.left
 
                 color: disabledPalette.text
-                textFormat: Text.RichText
                 renderType: settings.render_type
+                font.family: settings.font_family ? settings.font_family : textFieldImpl.font.family
+                font.pointSize: settings.font_pointSize > 0 ? settings.font_pointSize : textFieldImpl.font.pointSize
                 font.italic: pending
 
-                text: "<font size=-1>&lt;" +
-                      time.toLocaleTimeString(Qt.locale(), "hh:mm")
-                      + "&gt;</font>"
+                text: "<" + time.toLocaleTimeString(Qt.locale(), "hh:mm") + ">"
             }
 
             Item {
@@ -300,6 +301,8 @@ Item {
                     horizontalAlignment: Text.AlignLeft
                     wrapMode: Text.Wrap
                     color: textColor
+                    font.family: settings.font_family ? settings.font_family : textFieldImpl.font.family
+                    font.pointSize: settings.font_pointSize > 0 ? settings.font_pointSize : textFieldImpl.font.pointSize
                     renderType: settings.render_type
 
                     // TODO: In the code below, links should be resolved


### PR DESCRIPTION
Using the same font for the timestamp, author, message items and
input box creates a unified look.

The timestamp's font is not smaller anymore. The main reason behind
this decision is that it's challenging to perfectly align the
timestamp with different sized font to the first line of the
message which could be bothering. I don't think it's worth it.

Co-Authored-By: Denis Danilov <ddanilov@users.noreply.github.com>