### PR TITLE
TimelineItem: fix unpressable scrollbar in the details pane

### DIFF
--- a/client/qml/TimelineItem.qml
+++ b/client/qml/TimelineItem.qml
@@ -515,8 +515,6 @@ Item {
                     anchors.left: parent.left
                     anchors.leftMargin: 3
                     z: 1
-
-                    TimelineTextEditSelector {}
                 }
                 TextEdit {
                     text: "<a href=\"" + evtLink + "\">"+ eventId
@@ -532,9 +530,7 @@ Item {
 
                     onLinkActivated: Qt.openUrlExternally(link)
 
-                    TimelineTextEditSelector {}
-
-                    TimelineMouseArea {
+                    MouseArea {
                         anchors.fill: parent
                         cursorShape: parent.hoveredLink ?
                                          Qt.PointingHandCursor :
@@ -563,8 +559,6 @@ Item {
 
                 width: parent.width
                 anchors.top: detailsHeader.bottom
-
-                TimelineTextEditSelector {}
             }
         }
     }


### PR DESCRIPTION
We don't care about lost input focus when interacting with the
details pane anymore because it is a rare event. This careless
attitude is the best fix for the unpressable scrollbar there.

Got broken by 4fbcbb3e, closes #619