### PR TITLE
 TimelineItem: make ToolButtons's height fitting

### DIFF
--- a/client/qml/TimelineItem.qml
+++ b/client/qml/TimelineItem.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Controls 2.0 as QQC2
+import QtQuick.Controls.Styles 1.4
 //import QtGraphicalEffects 1.0 // For fancy highlighting
 import Quotient 1.0
 
@@ -419,11 +420,18 @@ Item {
                 id: resendButton
                 visible: failed
                 width: visible * implicitWidth
-                height: visible * implicitHeight
+                height: visible * textField.height
                 anchors.top: textField.top
                 anchors.right: discardButton.left
                 anchors.rightMargin: 2
                 text: qsTr("Resend")
+                style: ButtonStyle {
+                    label: Text {
+                      text: resendButton.text
+                      font.family: settings.font_family
+                      font.pointSize: settings.font_pointSize - 2
+                    }
+                  }
 
                 onClicked: room.retryMessage(eventId)
             }
@@ -432,11 +440,18 @@ Item {
                 visible: pending && marks !== EventStatus.ReachedServer
                          && marks !== EventStatus.Departed
                 width: visible * implicitWidth
-                height: visible * implicitHeight
+                height: visible * textField.height
                 anchors.top: textField.top
                 anchors.right: parent.right
                 anchors.rightMargin: 2
                 text: qsTr("Discard")
+                style: ButtonStyle {
+                    label: Text {
+                      text: discardButton.text
+                      font.family: settings.font_family
+                      font.pointSize: settings.font_pointSize - 2
+                    }
+                  }
 
                 onClicked: room.discardMessage(eventId)
             }
@@ -444,11 +459,18 @@ Item {
                 id: goToPredecessorButton
                 visible: !pending && eventResolvedType == "m.room.create" && refId
                 width: visible * implicitWidth
-                height: visible * implicitHeight
+                height: visible * textField.height
                 anchors.top: textField.top
                 anchors.right: parent.right
                 anchors.rightMargin: 2
                 text: qsTr("Go to\nolder room")
+                style: ButtonStyle {
+                    label: Text {
+                      text: goToPredecessorButton.text
+                      font.family: settings.font_family
+                      font.pointSize: settings.font_pointSize - 2
+                    }
+                  }
 
                 // TODO: Treat unjoined invite-only rooms specially
                 onClicked: controller.joinRequested(refId)
@@ -457,11 +479,18 @@ Item {
                 id: goToSuccessorButton
                 visible: !pending && eventResolvedType == "m.room.tombstone"
                 width: visible * implicitWidth
-                height: visible * implicitHeight
+                height: visible * textField.height
                 anchors.top: textField.top
                 anchors.right: parent.right
                 anchors.rightMargin: 2
                 text: qsTr("Go to\nnew room")
+                style: ButtonStyle {
+                    label: Text {
+                      text: goToSuccessorButton.text
+                      font.family: settings.font_family
+                      font.pointSize: settings.font_pointSize - 2
+                    }
+                  }
 
                 // TODO: Treat unjoined invite-only rooms specially
                 onClicked: controller.joinRequested(refId)

--- a/client/qml/TimelineItem.qml
+++ b/client/qml/TimelineItem.qml
@@ -22,8 +22,8 @@ Item {
         readonly property string timeline_style: value("UI/timeline_style", "")
         readonly property bool show_author_avatars:
             value("UI/show_author_avatars", timeline_style != "xchat")
-        readonly property string font_family: value("UI/Timeline/font_family", "")
-        readonly property string font_pointSize: value("UI/Timeline/font_pointSize", 0)
+        readonly property string font_family: value("UI/Timeline/font_family", "") ? value("UI/Timeline/font_family") : textFieldImpl.font.family
+        readonly property string font_pointSize: value("UI/Timeline/font_pointSize", 0) > 0 ? value("UI/Timeline/font_pointSize") : textFieldImpl.font.pointSize
     }
 
     // Property interface
@@ -197,8 +197,8 @@ Item {
 
                 color: authorColor
                 textFormat: Label.PlainText
-                font.family: settings.font_family ? settings.font_family : textFieldImpl.font.family
-                font.pointSize: settings.font_pointSize > 0 ? settings.font_pointSize : textFieldImpl.font.pointSize
+                font.family: settings.font_family
+                font.pointSize: settings.font_pointSize
                 font.bold: !xchatStyle
                 renderType: settings.render_type
 
@@ -231,8 +231,8 @@ Item {
 
                 color: disabledPalette.text
                 renderType: settings.render_type
-                font.family: settings.font_family ? settings.font_family : textFieldImpl.font.family
-                font.pointSize: settings.font_pointSize > 0 ? settings.font_pointSize : textFieldImpl.font.pointSize
+                font.family: settings.font_family
+                font.pointSize: settings.font_pointSize
                 font.italic: pending
 
                 text: "<" + time.toLocaleTimeString(Qt.locale(), "hh:mm") + ">"
@@ -301,8 +301,8 @@ Item {
                     horizontalAlignment: Text.AlignLeft
                     wrapMode: Text.Wrap
                     color: textColor
-                    font.family: settings.font_family ? settings.font_family : textFieldImpl.font.family
-                    font.pointSize: settings.font_pointSize > 0 ? settings.font_pointSize : textFieldImpl.font.pointSize
+                    font.family: settings.font_family
+                    font.pointSize: settings.font_pointSize
                     renderType: settings.render_type
 
                     // TODO: In the code below, links should be resolved

--- a/client/qml/TimelineItem.qml
+++ b/client/qml/TimelineItem.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Controls 2.0 as QQC2
-import QtQuick.Controls.Styles 1.4
 //import QtGraphicalEffects 1.0 // For fancy highlighting
 import Quotient 1.0
 
@@ -416,81 +415,37 @@ Item {
 
                 sourceComponent: FileContent { }
             }
-            ToolButton {
+            TimelineItemToolButton {
                 id: resendButton
                 visible: failed
-                width: visible * implicitWidth
-                height: visible * textField.height
-                anchors.top: textField.top
                 anchors.right: discardButton.left
-                anchors.rightMargin: 2
                 text: qsTr("Resend")
-                style: ButtonStyle {
-                    label: Text {
-                      text: resendButton.text
-                      font.family: settings.font_family
-                      font.pointSize: settings.font_pointSize - 2
-                    }
-                  }
 
                 onClicked: room.retryMessage(eventId)
             }
-            ToolButton {
+            TimelineItemToolButton {
                 id: discardButton
                 visible: pending && marks !== EventStatus.ReachedServer
                          && marks !== EventStatus.Departed
-                width: visible * implicitWidth
-                height: visible * textField.height
-                anchors.top: textField.top
                 anchors.right: parent.right
-                anchors.rightMargin: 2
                 text: qsTr("Discard")
-                style: ButtonStyle {
-                    label: Text {
-                      text: discardButton.text
-                      font.family: settings.font_family
-                      font.pointSize: settings.font_pointSize - 2
-                    }
-                  }
 
                 onClicked: room.discardMessage(eventId)
             }
-            ToolButton {
+            TimelineItemToolButton {
                 id: goToPredecessorButton
                 visible: !pending && eventResolvedType == "m.room.create" && refId
-                width: visible * implicitWidth
-                height: visible * textField.height
-                anchors.top: textField.top
                 anchors.right: parent.right
-                anchors.rightMargin: 2
                 text: qsTr("Go to\nolder room")
-                style: ButtonStyle {
-                    label: Text {
-                      text: goToPredecessorButton.text
-                      font.family: settings.font_family
-                      font.pointSize: settings.font_pointSize - 2
-                    }
-                  }
 
                 // TODO: Treat unjoined invite-only rooms specially
                 onClicked: controller.joinRequested(refId)
             }
-            ToolButton {
+            TimelineItemToolButton {
                 id: goToSuccessorButton
                 visible: !pending && eventResolvedType == "m.room.tombstone"
-                width: visible * implicitWidth
-                height: visible * textField.height
-                anchors.top: textField.top
                 anchors.right: parent.right
-                anchors.rightMargin: 2
                 text: qsTr("Go to\nnew room")
-                style: ButtonStyle {
-                    label: Text {
-                      text: goToSuccessorButton.text
-                      font.family: settings.font_family
-                      font.pointSize: settings.font_pointSize - 2
-                    }
-                  }
 
                 // TODO: Treat unjoined invite-only rooms specially
                 onClicked: controller.joinRequested(refId)

--- a/client/qml/TimelineItemToolButton.qml
+++ b/client/qml/TimelineItemToolButton.qml
@@ -1,0 +1,18 @@
+import QtQuick 2.6
+import QtQuick.Controls 1.4
+import QtQuick.Controls.Styles 1.4
+
+ToolButton {
+    width: visible * implicitWidth
+    height: visible * textField.height
+    anchors.top: textField.top
+    anchors.rightMargin: 2
+
+    style: ButtonStyle {
+        label: Text {
+          text: control.text
+          font.family: settings.font_family
+          font.pointSize: settings.font_pointSize - 2
+        }
+      }
+}

--- a/client/resources.qrc
+++ b/client/resources.qrc
@@ -16,5 +16,6 @@
         <file>qml/ActiveLabel.qml</file>
         <file>qml/TimelineMouseArea.qml</file>
         <file>qml/TimelineTextEditSelector.qml</file>
+        <file>qml/TimelineItemToolButton.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Line spacing in the timeline could change on the fly if the conditionally visible
buttons at the end of the line were taller than the text itself. It
could be annoying, especially for `discardButton`, because it is
visible at the beginning so each sent line's height shrinked once
which killed smooth scrolling animation. This problem was very
visible if smaller fonts were used for chatting than the default.