### PR TITLE
roomlist: show notificationCount in the tooltip

### DIFF
--- a/client/models/roomlistmodel.cpp
+++ b/client/models/roomlistmodel.cpp
@@ -459,6 +459,10 @@ QVariant RoomListModel::data(const QModelIndex& index, int role) const
             if (hlCount > 0)
                 result += "<br>" % tr("Unread highlights: %1").arg(hlCount);
 
+            auto nfCount = room->notificationCount();
+            if (nfCount > 0)
+                result += "<br>" % tr("Unread notifications: %1").arg(nfCount);
+
             result += "<br>" % tr("ID: %1").arg(room->id()) % "<br>";
             auto asUser = m_connections.size() < 2 ? QString() : ' ' +
                 tr("as %1",


### PR DESCRIPTION
It could help developers and advanced users to understand the
room's state and does not bother everyone else.