### PR TITLE
Fix ChatRoomWidget.readMarkerOnScreen tracking with local echo

### DIFF
--- a/client/qml/TimelineItem.qml
+++ b/client/qml/TimelineItem.qml
@@ -80,6 +80,10 @@ Item {
         if (!pending)
             controller.onMessageShownChanged(eventId, shown)
     }
+    onPendingChanged: {
+        if (!pending)
+            controller.onMessageShownChanged(eventId, shown)
+    }
 
     Component.onCompleted: {
         if (shown)


### PR DESCRIPTION
The symptom of this bug is the activity detector stopped working
after a message was sent to a room with enabled local echo (the
default).