### PR TITLE
Timeline: speed up rendering

### DIFF
--- a/client/qml/TimelineItem.qml
+++ b/client/qml/TimelineItem.qml
@@ -263,7 +263,7 @@ Item {
                              ? authorLabel.bottom : authorAvatar.top
                 anchors.left: xchatStyle ? authorLabel.right : timelabel.right
                 anchors.leftMargin: 1
-                anchors.right: resendButton.left
+                anchors.right: parent.right
                 anchors.rightMargin: 1
                 height: textFieldImpl.height
                 clip: true
@@ -409,6 +409,45 @@ Item {
 
                 sourceComponent: FileContent { }
             }
+            Loader {
+                id: buttonAreaLoader
+                active: failed || // resendButton
+                        (pending && marks !== EventStatus.ReachedServer && marks !== EventStatus.Departed) || // discardButton
+                        (!pending && eventResolvedType == "m.room.create" && refId) || // goToPredecessorButton
+                        (!pending && eventResolvedType == "m.room.tombstone") // goToSuccessorButton
+
+                anchors.top: textField.top
+                anchors.right: parent.right
+                height: textField.height
+
+                sourceComponent: buttonArea
+            }
+        }
+    }
+    Rectangle {
+        id: readMarkerLine
+
+        width: readMarker && parent.width
+        height: 3
+        anchors.horizontalCenter: fullMessage.horizontalCenter
+        anchors.bottom: fullMessage.bottom
+        Behavior on width { NumberAnimation {
+            duration: settings.animations_duration_ms
+            easing.type: Easing.OutQuad
+        }}
+
+        gradient: Gradient {
+            GradientStop { position: 0; color: "transparent" }
+            GradientStop { position: 1; color: defaultPalette.highlight }
+        }
+    }
+
+    // Components loaded on demand
+
+    Component {
+        id: buttonArea
+
+        Item {
             TimelineItemToolButton {
                 id: resendButton
                 visible: failed
@@ -446,25 +485,6 @@ Item {
             }
         }
     }
-    Rectangle {
-        id: readMarkerLine
-
-        width: readMarker && parent.width
-        height: 3
-        anchors.horizontalCenter: fullMessage.horizontalCenter
-        anchors.bottom: fullMessage.bottom
-        Behavior on width { NumberAnimation {
-            duration: settings.animations_duration_ms
-            easing.type: Easing.OutQuad
-        }}
-
-        gradient: Gradient {
-            GradientStop { position: 0; color: "transparent" }
-            GradientStop { position: 1; color: defaultPalette.highlight }
-        }
-    }
-
-    // Components loaded on demand
 
     Component {
         id: detailsArea

--- a/client/qml/TimelineItemToolButton.qml
+++ b/client/qml/TimelineItemToolButton.qml
@@ -4,8 +4,8 @@ import QtQuick.Controls.Styles 1.4
 
 ToolButton {
     width: visible * implicitWidth
-    height: visible * textField.height
-    anchors.top: textField.top
+    height: visible * parent.height
+    anchors.top: parent.top
     anchors.rightMargin: 2
 
     style: ButtonStyle {


### PR DESCRIPTION
It could make frequent operations like room changing and scrolling about two times faster (tested with Qt 5.11 .. 5.12 on Linux).

Seems like not `visible` ToolButtons are invisibly rendered by Qt for some reason which is a huge performance killer on the timeline. This patch allows those buttons to overlay the message but it's not a serious issue IMHO.