### PR TITLE
Show application icon on Plasma Wayland

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -40,6 +40,7 @@ int main( int argc, char* argv[] )
     QApplication::setApplicationName(QStringLiteral("quaternion"));
     QApplication::setApplicationDisplayName(QStringLiteral("Quaternion"));
     QApplication::setApplicationVersion(QStringLiteral("0.0.9.4+git"));
+    QApplication::setDesktopFileName(QStringLiteral("com.github.quaternion.desktop"));
 
     using Quotient::Settings;
     Settings::setLegacyNames(QStringLiteral("QMatrixClient"),


### PR DESCRIPTION
This is required to show the Quaternion icon on Wayland windows in a
Plasma Wayland session.

kwin_wayland fetches application icons from .desktop files and it
expects the desktop filename to be set on the QGuiApplication instance.

Without this, kwin sets a generic Wayland icon as fallback.