### PR TITLE
MessageEventModel: allow hiding some types of events

### DIFF
--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -260,6 +260,12 @@ void MainWindow::createMenu()
         tr("Show/hide meaningless activity (join-leave pairs and redacted events between)"),
         QStringLiteral("show_spammy")
     );
+    addTimelineOptionCheckbox(
+        showEventsMenu,
+        tr("Un&known event types"),
+        tr("Show/hide unknown event types"),
+        QStringLiteral("show_unknown_events")
+    );
 
     viewMenu->addSeparator();
 

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -205,6 +205,13 @@ void MainWindow::createMenu()
     auto showEventsMenu = viewMenu->addMenu(tr("&Display in timeline"));
     addTimelineOptionCheckbox(
         showEventsMenu,
+        tr("Invite events"),
+        tr("Show invite and withdrawn invitation events"),
+        QStringLiteral("show_invite"),
+        true
+    );
+    addTimelineOptionCheckbox(
+        showEventsMenu,
         tr("Normal &join/leave events"),
         tr("Show join and leave events"),
         QStringLiteral("show_joinleave"),
@@ -212,10 +219,39 @@ void MainWindow::createMenu()
     );
     addTimelineOptionCheckbox(
         showEventsMenu,
+        tr("Ban events"),
+        tr("Show ban and unban events"),
+        QStringLiteral("show_ban"),
+        true
+    );
+    showEventsMenu->addSeparator();
+    addTimelineOptionCheckbox(
+        showEventsMenu,
         tr("&Redacted events"),
         tr("Show redacted events in the timeline as 'Redacted'"
            " instead of hiding them entirely"),
         QStringLiteral("show_redacted")
+    );
+    addTimelineOptionCheckbox(
+        showEventsMenu,
+        tr("Changes in display na&me"),
+        tr("Show display name change"),
+        QStringLiteral("show_rename"),
+        true
+    );
+    addTimelineOptionCheckbox(
+        showEventsMenu,
+        tr("Avatar &changes"),
+        tr("Show avatar update events"),
+        QStringLiteral("show_avatar_update"),
+        true
+    );
+    addTimelineOptionCheckbox(
+        showEventsMenu,
+        tr("Room alias &updates"),
+        tr("Show room alias updates events"),
+        QStringLiteral("show_alias_update"),
+        true
     );
     addTimelineOptionCheckbox(
         showEventsMenu,

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -467,7 +467,8 @@ QVariant MessageEventModel::data(const QModelIndex& idx, int role) const
                             return text;
                         }
                         // Part 2: profile changes of joined members
-                        if (e.isRename())
+                        if (e.isRename()
+                            && Settings().value("UI/show_rename", true).toBool())
                         {
                             if (e.displayName().isEmpty())
                                 text = tr("cleared the display name");
@@ -475,7 +476,8 @@ QVariant MessageEventModel::data(const QModelIndex& idx, int role) const
                                 text = tr("changed the display name to %1")
                                        .arg(e.displayName().toHtmlEscaped());
                         }
-                        if (e.isAvatarUpdate())
+                        if (e.isAvatarUpdate()
+                            && Settings().value("UI/show_avatar_update", true).toBool())
                         {
                             if (!text.isEmpty())
                                 text += " and ";
@@ -664,12 +666,35 @@ QVariant MessageEventModel::data(const QModelIndex& idx, int role) const
             if (!e->replacedEvent().isEmpty())
                 return EventStatus::Hidden;
 
+        if ((is<RoomAliasesEvent>(evt) || is<RoomCanonicalAliasEvent>(evt))
+                && !Settings().value("UI/show_alias_update", true).toBool())
+            return EventStatus::Hidden;
+
         auto* memberEvent = timelineIt->viewAs<RoomMemberEvent>();
         if (memberEvent)
         {
             if ((memberEvent->isJoin() || memberEvent->isLeave()) &&
                     !Settings().value("UI/show_joinleave", true).toBool())
                 return EventStatus::Hidden;
+
+            if ((memberEvent->isInvite() || memberEvent->isRejectedInvite())
+                    && !Settings().value("UI/show_invite", true).toBool())
+                return EventStatus::Hidden;
+
+            if ((memberEvent->isBan() || memberEvent->isUnban())
+                    && !Settings().value("UI/show_ban", true).toBool())
+                return EventStatus::Hidden;
+
+            bool hideRename = memberEvent->isRename()
+                && (!memberEvent->isJoin() && !memberEvent->isLeave())
+                && !Settings().value("UI/show_rename", true).toBool();
+            bool hideAvatarUpdate = memberEvent->isAvatarUpdate()
+                && !Settings().value("UI/show_avatar_update", true).toBool();
+            if ((hideRename && hideAvatarUpdate)
+                    || (hideRename && !memberEvent->isAvatarUpdate())
+                    || (hideAvatarUpdate && !memberEvent->isRename())) {
+                return EventStatus::Hidden;
+            }
         }
         if (memberEvent || evt.isRedacted())
         {

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -719,6 +719,10 @@ QVariant MessageEventModel::data(const QModelIndex& idx, int role) const
                 !Settings().value("UI/show_noop_events").toBool())
             return EventStatus::Hidden;
 
+        if (!evt.isStateEvent() && !is<RoomMessageEvent>(evt)
+                && !Settings().value("UI/show_unknown_events").toBool())
+            return EventStatus::Hidden;
+
         return evt.isReplaced() ? EventStatus::Replaced : EventStatus::Normal;
     }
 


### PR DESCRIPTION
Invites, ban events, display name changes, avatar changes, and unknown events can be now hidden.

Closes: #411
Closes: #487
Closes: #581