### PR TITLE
MessageEventModel: hide replacement events

### DIFF
--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -658,6 +658,11 @@ QVariant MessageEventModel::data(const QModelIndex& idx, int role) const
         if (is<RedactionEvent>(evt))
             return EventStatus::Hidden;
 
+        // isReplacement?
+        if (auto e = eventCast<const RoomMessageEvent>(&evt))
+            if (!e->replacedEvent().isEmpty())
+                return EventStatus::Hidden;
+
         auto* memberEvent = timelineIt->viewAs<RoomMemberEvent>();
         if (memberEvent)
         {


### PR DESCRIPTION
Its result is visible inplace of the original event.