### PR TITLE
Fix resizing of the text selection

### DIFF
--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -52,7 +52,7 @@ class ChatRoomWidget: public QWidget
         bool pendingMarkRead() const;
 
         QStringList findCompletionMatches(const QString& pattern) const;
-        Qt::KeyboardModifiers getModifierKeys() const;
+        Q_INVOKABLE Qt::KeyboardModifiers getModifierKeys() const;
 
     signals:
         void joinRequested(const QString& roomAlias);


### PR DESCRIPTION
Creating a new selection in the same message resulted in:
```
qrc:/qml/TimelineTextEditSelector.qml:22: TypeError: Property 'getModifierKeys' of object ChatRoomWidget(0x5616507a9ca0) is not a function
```