### PR TITLE
Timeline: fix scrolling issues when latest room event is hidden

### DIFF
--- a/client/qml/Timeline.qml
+++ b/client/qml/Timeline.qml
@@ -242,8 +242,9 @@ Rectangle {
 
             section.property: "section"
 
+            readonly property bool atBeginning: contentY + height == 0
             readonly property int largestVisibleIndex: count > 0 ?
-                indexAt(contentX, contentY + height - 1) : -1
+                atBeginning ? 0 : indexAt(contentX, contentY + height - 1) : -1
             readonly property bool loadingHistory:
                 room ? room.eventsHistoryJob : false
             readonly property bool noNeedMoreContent:


### PR DESCRIPTION
If latest room event was a hidden one, `largestVisibleIndex` has
not been set to zero even if users have scrolled to the bottom. As
a consequence, room was not followed any more which led to annoying
scrolling issues.