### PR TITLE
Add menu and system icon to the tray icon

### DIFF
--- a/client/linuxutils.h
+++ b/client/linuxutils.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2017 Elvis Angelaccio <elvis.angelaccio@kde.org>
+ * Copyright (C) 2020 The Quotient project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QtCore/QFileInfo>
+
+inline bool inFlatpak() {
+    return QFileInfo::exists("/.flatpak-info");
+}
+
+inline QString appIconName() {
+    return inFlatpak() ? "com.github.quaternion" : "quaternion";
+}

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -100,6 +100,7 @@ MainWindow::MainWindow()
              chatRoomWidget, &ChatRoomWidget::insertMention);
 
     createMenu();
+    createWinId();
     systemTrayIcon = new SystemTrayIcon(this);
     systemTrayIcon->show();
 

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -26,6 +26,7 @@
 #include "networkconfigdialog.h"
 #include "roomdialogs.h"
 #include "systemtrayicon.h"
+#include "linuxutils.h"
 
 #include <csapi/joining.h>
 #include <connection.h>
@@ -78,7 +79,7 @@ MainWindow::MainWindow()
     connect(nam, &QNetworkAccessManager::sslErrors,
             this, &MainWindow::sslErrors);
 
-    setWindowIcon(QIcon(":/icon.png"));
+    setWindowIcon(QIcon::fromTheme(appIconName(), QIcon(":/icon.png")));
 
     roomListDock = new RoomListDock(this);
     addDockWidget(Qt::LeftDockWidgetArea, roomListDock);

--- a/client/systemtrayicon.cpp
+++ b/client/systemtrayicon.cpp
@@ -19,8 +19,13 @@
 
 #include "systemtrayicon.h"
 
+#include <QtGui/QWindow>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QMenu>
+
 #include "mainwindow.h"
 #include "quaternionroom.h"
+#include "linuxutils.h"
 #include <settings.h>
 #include <qt_connection_util.h>
 
@@ -28,8 +33,16 @@ SystemTrayIcon::SystemTrayIcon(MainWindow* parent)
     : QSystemTrayIcon(parent)
     , m_parent(parent)
 {
+    auto contextMenu = new QMenu(parent);
+    auto showHideAction = contextMenu->addAction(tr("Hide"), this, &SystemTrayIcon::showHide);
+    contextMenu->addAction(tr("Quit"), QApplication::quit);
+    connect(m_parent->windowHandle(), &QWindow::visibleChanged, [showHideAction](bool visible) {
+        showHideAction->setText(visible ? tr("Hide") : tr("Show"));
+    });
+
     setIcon(QIcon(":/icon.png"));
     setToolTip("Quaternion");
+    setContextMenu(contextMenu);
     connect( this, &SystemTrayIcon::activated, this, &SystemTrayIcon::systemTrayIconAction);
 }
 

--- a/client/systemtrayicon.cpp
+++ b/client/systemtrayicon.cpp
@@ -40,7 +40,7 @@ SystemTrayIcon::SystemTrayIcon(MainWindow* parent)
         showHideAction->setText(visible ? tr("Hide") : tr("Show"));
     });
 
-    setIcon(QIcon(":/icon.png"));
+    setIcon(QIcon::fromTheme(appIconName(), QIcon(":/icon.png")));
     setToolTip("Quaternion");
     setContextMenu(contextMenu);
     connect( this, &SystemTrayIcon::activated, this, &SystemTrayIcon::systemTrayIconAction);


### PR DESCRIPTION
SystemTrayIcon is splitted into QtTrayIcon (cross-platform implementation) and SNITrayIcon (linux-only implementation).
SNITrayIcon offers a flatpak-compatible tray icon with fallback to Qt tray icon, what should work on all desktop environments and window managers.

However, SNITrayIcon supports only name-based tray icon (it is possible to set a pixmap, but then, probably, [the indicator-application-service hack](https://github.com/qt/qtbase/blob/ba3b53cb501a77144aa6259e48a8e0edc3d1481d/src/platformsupport/themes/genericunix/dbustray/qdbustrayicon.cpp#L195-L222) should be implemented) and doesn't support clicking on notifications (I think, it is better to implement a separate notification manager class that could implement dbus notification spec, but for now it as is)

Due to these cons, I think, it is better to use SNITrayIcon only in flatpak for now (Quaternion uses an XEmbed tray icon in flatpak currently that doesn't work well on modern desktop environments (gnome, kde, etc) and offers Qt's custom baloon notifications)

And I'm not sure where to place inFlatpak and appIconName methods :thinking: 

This PR also offers system icon theme usage for tray icon and a two item menu, i.e. closes #680