### PR TITLE
ChatRoomWidget: check if m_fileToAttach is opened

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -221,7 +221,8 @@ void ChatRoomWidget::setRoom(QuaternionRoom* room)
     indicesOnScreen.clear();
     attachedFileName.clear();
     m_attachAction->setChecked(false);
-    m_fileToAttach->remove();
+    if (m_fileToAttach->isOpen())
+        m_fileToAttach->remove();
 
     m_currentRoom = room;
     m_attachAction->setEnabled(m_currentRoom != nullptr);


### PR DESCRIPTION
Removes the "QFile::remove: Empty or null file name" message when changing rooms