### PR TITLE
Initial support for rich text sending

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ message( STATUS )
 set(quaternion_SRCS
     client/accountregistry.cpp
     client/quaternionroom.cpp
+    client/htmlfilter.cpp
     client/imageprovider.cpp
     client/activitydetector.cpp
     client/dialog.cpp
@@ -186,6 +187,7 @@ set(quaternion_TS
     client/translations/quaternion_de.ts
     client/translations/quaternion_pl.ts
     client/translations/quaternion_ru.ts
+    client/translations/quaternion_es.ts
     )
 QT5_ADD_TRANSLATION(quaternion_QM ${quaternion_TS})
 

--- a/client/chatedit.cpp
+++ b/client/chatedit.cpp
@@ -19,10 +19,11 @@
 
 #include "chatedit.h"
 
-#include <QtCore/QMimeData>
-#include <QtGui/QKeyEvent>
-
 #include "chatroomwidget.h"
+
+#include <QtGui/QKeyEvent>
+#include <QtCore/QMimeData>
+#include <QtCore/QStringBuilder>
 
 ChatEdit::ChatEdit(ChatRoomWidget* c)
     : KChatEdit(c), chatRoomWidget(c), matchesListPosition(0)
@@ -77,12 +78,12 @@ void ChatEdit::startNewCompletion()
 {
     completionCursor = textCursor();
     completionCursor.clearSelection();
-    while ( completionCursor.movePosition(QTextCursor::PreviousCharacter, QTextCursor::KeepAnchor) )
-    {
-        QChar firstChar = completionCursor.selectedText().at(0);
-        if (!firstChar.isLetterOrNumber() && firstChar != '@')
-        {
-            completionCursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor);
+    while (completionCursor.movePosition(QTextCursor::PreviousCharacter,
+                                         QTextCursor::KeepAnchor)) {
+        const auto& firstChar = completionCursor.selectedText().at(0);
+        if (!firstChar.isLetterOrNumber() && firstChar != '@') {
+            completionCursor.movePosition(QTextCursor::NextCharacter,
+                                          QTextCursor::KeepAnchor);
             break;
         }
     }

--- a/client/chatedit.cpp
+++ b/client/chatedit.cpp
@@ -161,8 +161,8 @@ void ChatEdit::insertMention(QString author)
     QString postfix;
     if (cursor.atStart())
         postfix = QStringLiteral(":");
-    if (pickingMentions && document()->characterAt(cursor.position()) == ':')
-    {
+    if ((pickingMentions || isCompletionActive())
+        && document()->characterAt(cursor.position()) == ':') {
         cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor);
         cursor.insertText(QStringLiteral(","));
         postfix = QStringLiteral(":");
@@ -174,4 +174,5 @@ void ChatEdit::insertMention(QString author)
     if (!postfix.isEmpty())
         insertPlainText(postfix);
     pickingMentions = true;
+    cancelCompletion();
 }

--- a/client/chatedit.h
+++ b/client/chatedit.h
@@ -33,6 +33,7 @@ class ChatEdit : public KChatEdit
 
         void triggerCompletion();
         void cancelCompletion();
+        bool isCompletionActive();
 
         void insertMention(QString author);
 
@@ -58,7 +59,11 @@ class ChatEdit : public KChatEdit
 
         bool pickingMentions = false;
 
-        void startNewCompletion();
+        /// \brief Initialise a new completion
+        ///
+        /// \return true if completion matches exist for the current entry;
+        ///         false otherwise
+        bool initCompletion();
         void appendTextAtCursor(const QString& text, bool select = false);
         void keyPressEvent(QKeyEvent* event) override;
 };

--- a/client/chatedit.h
+++ b/client/chatedit.h
@@ -35,7 +35,7 @@ class ChatEdit : public KChatEdit
         void cancelCompletion();
         bool isCompletionActive();
 
-        void insertMention(QString author);
+        void insertMention(QString author, QUrl url);
 
     public slots:
         void switchContext(QObject* contextKey) override;
@@ -46,7 +46,6 @@ class ChatEdit : public KChatEdit
         void insertFromMimeDataRequested(const QMimeData* source);
 
     protected:
-        QString sanitizeMention(QString mentionText);
         bool canInsertFromMimeData(const QMimeData* source) const override;
         void insertFromMimeData(const QMimeData* source) override;
 
@@ -54,7 +53,8 @@ class ChatEdit : public KChatEdit
         ChatRoomWidget* chatRoomWidget;
 
         QTextCursor completionCursor;
-        QStringList completionMatches;
+        /// Text/href pairs for completion
+        QVector<QPair<QString, QUrl>> completionMatches;
         int matchesListPosition;
 
         bool pickingMentions = false;
@@ -64,7 +64,8 @@ class ChatEdit : public KChatEdit
         /// \return true if completion matches exist for the current entry;
         ///         false otherwise
         bool initCompletion();
-        void appendTextAtCursor(const QString& text, bool select = false);
+        void appendMentionAt(QTextCursor& cursor, QString mention,
+                             QUrl mentionUrl, bool select);
         void keyPressEvent(QKeyEvent* event) override;
 };
 

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -534,7 +534,7 @@ void ChatRoomWidget::sendMessage()
 QString ChatRoomWidget::sendCommand(QStringRef command, QString argString)
 {
     static const QRegularExpression
-        RoomIdRE { "^([#!][^:[:blank:]]]+):" % ServerPartPattern % '$', ReFlags },
+        RoomIdRE { "^([#!][^:[:blank:]]+):" % ServerPartPattern % '$', ReFlags },
         UserIdRE { '^' % UserIdPattern % '$', ReFlags };
     Q_ASSERT(RoomIdRE.isValid() && UserIdRE.isValid());
 

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -74,8 +74,8 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
         qmlRegisterAnonymousType<GetRoomEventsJob>("Quotient", 1);
 #else
         qmlRegisterType<GetRoomEventsJob>();
-        qRegisterMetaType<GetRoomEventsJob*>("GetRoomEventsJob*");
 #endif
+        qRegisterMetaType<GetRoomEventsJob*>("GetRoomEventsJob*");
         qRegisterMetaType<User*>("User*");
         qmlRegisterType<Settings>("Quotient", 1, 0, "Settings");
         qmlRegisterUncreatableType<RoomMessageEvent>("Quotient", 1, 0,

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -709,6 +709,24 @@ QString ChatRoomWidget::sendCommand(QStringRef command, QString argString)
             QTextDocumentFragment::fromHtml(cleanHtml).toPlainText(), cleanHtml);
         return {};
     }
+    if (command == "md") {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        // https://bugreports.qt.io/browse/QTBUG-86603
+        static constexpr auto MdFeatures = QTextDocument::MarkdownFeatures(
+            QTextDocument::MarkdownNoHTML
+            | QTextDocument::MarkdownDialectCommonMark);
+        m_chatEdit->setMarkdown(argString);
+        // TODO: doesn't work yet since sanitizeHtml doesn't support conversion
+        // of <span>s to which MD marks are exported, to Matrix-accepted HTML
+        // tags; instead, font-weight etc. are simply stripped from spans,
+        // dropping MD formatting.
+        m_currentRoom->postHtmlText(m_chatEdit->toMarkdown(MdFeatures).trimmed(),
+                                    sanitizeHtml(m_chatEdit->toHtml()));
+        return {};
+#else
+        return tr("Your build of Quaternion doesn't support Markdown");
+#endif
+    }
     if (command == "query" || command == "dc")
     {
         if (argString.isEmpty())

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -128,7 +128,7 @@ class ChatRoomWidget: public QWidget
         void reStartShownTimer();
         void sendFile();
         void sendMessage();
-        [[nodiscard]] QString sendCommand(QStringRef command, QString argString);
+        [[nodiscard]] QString sendCommand(const QStringRef &command, const QString &argString);
 
         void timerEvent(QTimerEvent* qte) override;
         void resizeEvent(QResizeEvent*) override;

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -126,7 +126,9 @@ class ChatRoomWidget: public QWidget
         QString selectedText;
 
         void reStartShownTimer();
-        QString doSendInput();
+        void sendFile();
+        void sendMessage();
+        [[nodiscard]] QString sendCommand(QStringRef command, QString argString);
 
         void timerEvent(QTimerEvent* qte) override;
         void resizeEvent(QResizeEvent*) override;

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -55,7 +55,7 @@ class ChatRoomWidget: public QWidget
         void enableDebug();
         bool pendingMarkRead() const;
 
-        QStringList findCompletionMatches(const QString& pattern) const;
+        QVector<QPair<QString, QUrl> > findCompletionMatches(const QString& pattern) const;
         Q_INVOKABLE Qt::KeyboardModifiers getModifierKeys() const;
 
     signals:

--- a/client/htmlfilter.cpp
+++ b/client/htmlfilter.cpp
@@ -193,14 +193,14 @@ QString process(QString html, [[maybe_unused]] QuaternionRoom* context)
             ReOpt),
         "&amp;");
 
-    if constexpr (Dir == MatrixToQt) {
-        // Wrap in a no-op tag to make the text look like valid XML
+    // Wrap in a no-op tag to make the text look like valid XML; Qt's rich
+    // text engine produces valid XHTML so QtToMatrix doesn't need this.
+    if constexpr (Dir == MatrixToQt)
         html = "<body>" + html + "</body>";
-    }
 
     QXmlStreamReader reader(html);
-    QString cleanHtml;
-    QXmlStreamWriter writer(&cleanHtml);
+    QString resultHtml;
+    QXmlStreamWriter writer(&resultHtml);
     writer.setAutoFormatting(false);
 
     stack<int> tagsStack;
@@ -285,10 +285,10 @@ QString process(QString html, [[maybe_unused]] QuaternionRoom* context)
             continue;
         }
     }
-    if (cleanHtml.startsWith('\n')) // added after <body> as of Qt 5.15 at least
-        cleanHtml.remove(0, 1);
+    if (resultHtml.startsWith('\n')) // added after <body> as of Qt 5.15 at least
+        resultHtml.remove(0, 1);
 
-    return cleanHtml;
+    return resultHtml;
 }
 } // namespace HtmlFilter
 

--- a/client/htmlfilter.cpp
+++ b/client/htmlfilter.cpp
@@ -275,9 +275,8 @@ Result process(QString html, [[maybe_unused]] QuaternionRoom* context,
             // and report
             if (parsingMode == Validating) {
                 result.errorPos = pos;
-                result.errorString =
-                    QStringLiteral("Non-tag or disallowed tag: %1")
-                        .arg(uncheckedHtml.left(gtPos - tagNamePos));
+                result.errorString = "Non-tag or disallowed tag: "
+                                     % uncheckedHtml.left(gtPos - tagNamePos);
                 return result;
             }
             html.remove(pos, html.indexOf('>', tagNamePos) - pos + 1);

--- a/client/htmlfilter.cpp
+++ b/client/htmlfilter.cpp
@@ -185,8 +185,14 @@ QString process(QString html, [[maybe_unused]] QuaternionRoom* context)
     html.replace(QRegularExpression("<br[^/<>]*>", ReOpt), "<br />");
     html.replace(QRegularExpression("<hr[^/<>]*>", ReOpt), "<hr />");
     html.replace(QRegularExpression("<img([^/<>])*>", ReOpt), "<img\\1 />");
-    html.replace(QRegularExpression("&([[:alpha:]]*($|[^[:alpha:];]))", ReOpt),
-                 "&amp;\\1");
+    // Escape ampersands outside of character entities
+    // (HTML tolerates it, XML doesn't)
+    html.replace(
+        QRegularExpression(
+            "&(?!(#[0-9]+|#x[0-9a-fA-F]+|[[:alpha:]_][-[:alnum:]_:.]*);)",
+            ReOpt),
+        "&amp;");
+
     if constexpr (Dir == MatrixToQt) {
         // Wrap in a no-op tag to make the text look like valid XML
         html = "<body>" + html + "</body>";

--- a/client/htmlfilter.cpp
+++ b/client/htmlfilter.cpp
@@ -1,0 +1,297 @@
+#include "htmlfilter.h"
+
+#include <QtCore/QRegularExpression>
+#include <QtCore/QXmlStreamReader>
+#include <QtCore/QXmlStreamWriter>
+#include <QtCore/QDebug>
+
+#include <stack>
+
+using namespace std;
+
+namespace HtmlFilter {
+
+enum Direction : unsigned char { QtToMatrix, MatrixToQt };
+
+constexpr const char* permittedTags[] = {
+    "font",       "del", "h1",    "h2",     "h3",      "h4",     "h5",   "h6",
+    "blockquote", "p",   "a",     "ul",     "ol",      "sup",    "sub",  "li",
+    "b",          "i",   "u",     "strong", "em",      "strike", "code", "hr",
+    "br",         "div", "table", "thead",  "tbody",   "tr",     "th",   "td",
+    "caption",    "pre", "span",  "img",    "mx-reply"
+};
+
+struct PassList {
+    const char* tag;
+    vector<const char*> allowedAttrs;
+};
+
+// See filterTag() on special processing of commented out tags/attributes
+const PassList passLists[] = {
+    { "a", { "name", "target", "href" /* only allowed schemes */ } },
+    { "img", { "width", "height", "alt", "title", "src" /* only 'mxc:' */ } },
+    { "ol", { "start" } },
+    { "font", { "color" /*, "data-mx-(bg-)?color" */ } },
+    { "span", { "color" /* "data-mx-(bg-)?color" */ } },
+    { "code", { /* "class" */ } },
+};
+
+const auto& htmlColorAttr = QStringLiteral("color");
+const auto& htmlStyleAttr = QStringLiteral("style");
+const auto& mxColorAttr = QStringLiteral("data-mx-color");
+const auto& mxBgColorAttr = QStringLiteral("data-mx-bg-color");
+
+template <size_t Len>
+inline QStringRef cssValue(const QStringRef& css,
+                           const char (&propertyNameWithColon)[Len])
+{
+    return css.startsWith(propertyNameWithColon)
+               ? css.mid(Len - 1).trimmed()
+               : QStringRef();
+}
+
+using rewrite_t = vector<pair<QString, QXmlStreamAttributes>>;
+
+template <Direction Dir>
+rewrite_t filterTag(const QStringRef& tag, QXmlStreamAttributes attributes,
+                    bool firstElement)
+{
+    if (tag == "mx-reply") {
+        // As per the spec, `<mx-reply>` can only come at the very
+        // beginning, with no attributes allowed; and should be
+        // treated as `<div>`; so deal with it as a special case
+        if (!firstElement)
+            return {};
+
+        if constexpr (Dir == MatrixToQt)
+            return { { "div", {} } };
+        // For QtToMatrix, just pass `<mx-reply>` to the wire in a usual way
+    }
+
+    if (find(begin(permittedTags), end(permittedTags), tag) == end(permittedTags))
+        return {}; // The tag is not allowed
+
+    rewrite_t rewrite { { tag.toString(), {} } };
+    if (tag == "code") { // Special case
+        copy_if(attributes.begin(), attributes.end(),
+                back_inserter(rewrite.back().second), [](const auto& a) {
+                    return a.qualifiedName() == "class"
+                           && a.value().startsWith("language-");
+                });
+        return rewrite;
+    }
+
+    const auto it =
+        find_if(begin(passLists), end(passLists),
+                [&tag](const auto& passCard) { return passCard.tag == tag; });
+    if (it == end(passLists))
+        return rewrite; // Drop all attributes, pass the tag
+
+    const auto& passList = it->allowedAttrs;
+    for (auto&& a: attributes) {
+        /// Find the first element in the rewrite that would accept color
+        /// attributes (`font` and, only in Matrix HTML, `span`),
+        /// and add the passed attribute to it
+        const auto& addColorAttr = [&rewrite](const QString& attrName,
+                                              const QStringRef& attrValue) {
+            auto it = find_if(rewrite.begin(), rewrite.end(),
+                              [](const rewrite_t::value_type& element) {
+                                  return element.first == "font"
+                                         || (Dir == QtToMatrix
+                                             && element.first == "span");
+                              });
+            if (it == rewrite.end())
+                it = rewrite.insert(rewrite.end(), { "font", {} });
+            it->second.append(attrName, attrValue.toString());
+        };
+        if constexpr (Dir == MatrixToQt) {
+            if (a.qualifiedName() == mxColorAttr)
+                addColorAttr(htmlColorAttr, a.value());
+            else if (a.qualifiedName() == mxBgColorAttr)
+                rewrite.front().second.append(htmlStyleAttr,
+                                              "background-color:" + a.value());
+        } else {
+            if (a.qualifiedName() == htmlStyleAttr) {
+                const auto& cssProperties = a.value().split(';');
+                for (auto p: cssProperties) {
+                    p = p.trimmed();
+                    if (p.isEmpty())
+                        continue;
+                    if (const auto& v = cssValue(p, "color:"); !v.isEmpty()) {
+                        addColorAttr(mxColorAttr, v);
+                    } else if (const auto& v = cssValue(p, "background-color:");
+                               !v.isEmpty())
+                        addColorAttr(mxBgColorAttr, v);
+                    else if (const auto& v = cssValue(p, "font-weight:");
+                             v == "bold" || v == "bolder" || v.toFloat() > 500)
+                        rewrite.emplace_back().first = "b";
+                    else if (const auto& v = cssValue(p, "font-style:");
+                             v == "italic" || v.startsWith("oblique"))
+                        rewrite.emplace_back().first = "i";
+                    else {
+                        const auto& fontFamilies =
+                            cssValue(p, "font-family:").split(',');
+                        for (auto ff: fontFamilies) {
+                            ff = ff.trimmed();
+                            if (ff.isEmpty())
+                                continue;
+                            if (ff[0] == '\'' || ff[0] == '"')
+                                ff = ff.mid(1);
+                            if (ff.startsWith("monospace")) {
+                                rewrite.emplace_back().first = "code";
+                                break;
+                            }
+                        }
+                    }
+                }
+            } else if (a.qualifiedName() == htmlColorAttr)
+                addColorAttr(mxColorAttr, a.value());
+        }
+        if (tag == "a" && a.qualifiedName() == "href") {
+            const char* const permittedSchemes[] {
+                "http:", "https:", "ftp:", "mailto:", "magnet:", "matrix:"
+            };
+            if (none_of(begin(permittedSchemes), end(permittedSchemes),
+                        [&a](const char* s) { return a.value().startsWith(s); }))
+                continue;
+        }
+        if (tag == "img" && a.qualifiedName() == "src"
+            && !a.value().startsWith("mxc:"))
+            continue;
+
+        if (find(passList.begin(), passList.end(), a.qualifiedName())
+            != passList.end())
+            rewrite.front().second.push_back(move(a));
+    }
+    rewrite.erase(remove_if(rewrite.begin(), rewrite.end(),
+                            [](const rewrite_t::value_type& i) {
+                                // No sense in these tags without attributes
+                                return i.second.empty()
+                                       && (i.first == "font"
+                                           || i.first == "span");
+                            }),
+                  rewrite.end());
+
+    return rewrite;
+}
+
+template <Direction Dir>
+QString process(QString html, [[maybe_unused]] QuaternionRoom* context)
+{
+    // Massage html to make it more like XHTML, since Qt doesn't have an
+    // HTML parser (outside of QTextDocument) and the XML parser is quite
+    // picky about properly closed tags and escaped ampersands.
+    constexpr auto ReOpt = QRegularExpression::CaseInsensitiveOption;
+    html.replace(QRegularExpression("<br[^/<>]*>", ReOpt), "<br />");
+    html.replace(QRegularExpression("<hr[^/<>]*>", ReOpt), "<hr />");
+    html.replace(QRegularExpression("<img([^/<>])*>", ReOpt), "<img\\1 />");
+    html.replace(QRegularExpression("&([[:alpha:]]*($|[^[:alpha:];]))", ReOpt),
+                 "&amp;\\1");
+    if constexpr (Dir == MatrixToQt) {
+        // Wrap in a no-op tag to make the text look like valid XML
+        html = "<body>" + html + "</body>";
+    }
+
+    QXmlStreamReader reader(html);
+    QString cleanHtml;
+    QXmlStreamWriter writer(&cleanHtml);
+    writer.setAutoFormatting(false);
+
+    stack<int> tagsStack;
+    for (bool firstElement = true; !reader.atEnd();) {
+        switch (reader.readNext()) {
+        case QXmlStreamReader::NoToken:
+            Q_ASSERT(reader.tokenType() != QXmlStreamReader::NoToken /*false*/);
+            continue;
+        case QXmlStreamReader::StartDocument:
+        case QXmlStreamReader::Comment:
+        case QXmlStreamReader::DTD:
+        case QXmlStreamReader::ProcessingInstruction:
+            continue;
+        case QXmlStreamReader::Invalid:
+            qCritical().noquote() << "Invalid XHTML:" << html;
+            qCritical().nospace() << "Error at char " << reader.characterOffset()
+                                  << ": " << reader.errorString();
+            qCritical().noquote()
+                << "Buffer at error:" << html.mid(reader.characterOffset());
+            writer.writeEndDocument();
+            continue;
+        case QXmlStreamReader::EndDocument:
+            if (!tagsStack.empty())
+                qDebug() << "filterHtml(): Not all HTML tags closed";
+            continue;
+        case QXmlStreamReader::StartElement: {
+            const auto& tagName = reader.qualifiedName();
+            if (tagName == "head") { // Qt pushes styles in it, not interesting
+                reader.skipCurrentElement();
+                continue;
+            }
+            if (tagName == "html" || tagName == "body")
+                continue; // Just ignore those, get to the content
+
+            // Skip the first top-level <p> and replace further top-level
+            // `<p>...</p>` with `<br/>...` - kinda controversial but
+            // there's no cleaner way to get rid of the single top-level <p>
+            // generated by Qt without assuming that it's the only <p>
+            // spanning the whole body (copy-pasting rich text from other
+            // editors can bring several legitimate paragraphs of text,
+            // e.g.). This is also a very special case where a converted tag
+            // is immediately closed, unlike the one in the source text;
+            // which is why it's checked here rather than in filterTag().
+            if (tagName == "p" && tagsStack.empty()) {
+                tagsStack.emplace(0);
+                if (!firstElement)
+                    writer.writeEmptyElement("br");
+            } else {
+                const auto& rewrite =
+                    filterTag<Dir>(tagName, reader.attributes(), firstElement);
+
+                // It's only enough to remember the number of elements,
+                // as QXmlStreamWriter remembers the tag names anyway.
+                tagsStack.emplace(rewrite.size());
+                if (tagsStack.size() > 100)
+                    qCritical() << "CS API spec limits HTML tags depth at 100";
+
+                for (const auto& [tag, attrs]: rewrite) {
+                    writer.writeStartElement(tag);
+                    writer.writeAttributes(attrs);
+                }
+            }
+            firstElement = false;
+            continue;
+        }
+        case QXmlStreamReader::Characters:
+        case QXmlStreamReader::EntityReference:
+            writer.writeCurrentToken(reader);
+            continue;
+        case QXmlStreamReader::EndElement:
+            if (tagsStack.empty()) {
+                const auto& tagName = reader.qualifiedName();
+                if (tagName != "body" && tagName != "html")
+                    qWarning() << "filterHtml(): empty tags stack, skipping"
+                               << ('/' + tagName);
+                continue;
+            }
+            // Close as many elements as were opened in case StartElement
+            for (auto& i = tagsStack.top(); i > 0; --i)
+                writer.writeEndElement();
+            tagsStack.pop();
+            continue;
+        }
+    }
+    if (cleanHtml.startsWith('\n')) // added after <body> as of Qt 5.15 at least
+        cleanHtml.remove(0, 1);
+
+    return cleanHtml;
+}
+} // namespace HtmlFilter
+
+QString filterQtHtmlToMatrix(const QString &html, QuaternionRoom *context)
+{
+    return HtmlFilter::process<HtmlFilter::QtToMatrix>(html, context);
+}
+
+QString filterMatrixHtmlToQt(const QString &html, QuaternionRoom *context)
+{
+    return HtmlFilter::process<HtmlFilter::MatrixToQt>(html, context);
+}

--- a/client/htmlfilter.h
+++ b/client/htmlfilter.h
@@ -4,33 +4,73 @@
 
 class QuaternionRoom;
 
+namespace HtmlFilter {
+Q_NAMESPACE
+
+enum ParsingMode { Tolerant = 0, Validating = 1 };
+Q_ENUM_NS(ParsingMode)
+
+/*! \brief Result structure for Matrix HTML parsing
+ *
+ * This is the return type of matrixToQt(), which, unlike qtToMatrix(),
+ * can't assume that HTML it receives is valid since it either comes from
+ * the wire or a user input and therefore need a means to report an error when
+ * the parser cannot cope (most often because of incorrectly closed tags).
+ *
+ * \sa matrixToQt()
+ */
+struct Result {
+    Q_GADGET
+    Q_PROPERTY(QString filteredHtml MEMBER filteredHtml CONSTANT)
+    Q_PROPERTY(int errorPos MEMBER errorPos CONSTANT)
+    Q_PROPERTY(QString errorString MEMBER errorString CONSTANT)
+
+public:
+    /// HTML that the filter managed to produce (incomplete in case of error)
+    QString filteredHtml {};
+    /// The position at which the first error was encountered; -1 if no error
+    int errorPos = -1;
+    /// The human-readable error message; empty if no error
+    QString errorString {};
+};
+
 /*! \brief Make the passed HTML compliant with Matrix requirements
  *
  * This function removes HTML tags disallowed in Matrix; on top of that,
  * it cleans away extra parts (DTD, `head`, top-level `p`, extra `span`
  * inside hyperlinks etc.) added by Qt when exporting QTextDocument
  * to HTML, and converts some formatting accepted in Matrix to tags
- * attributes allowed by the CS API spec. It requires at least a `<body>` pair
- * of tags to be there and assumes well-formed HTML (i.e. it doesn't recover
- * from missing closing tags, except `br`, `hr` and `img`).
+ * attributes allowed by the CS API spec.
+ *
+ * \note This function assumes well-formed XHTML produced by Qt classes; while
+ *       it corrects unescaped ampersands (`&`) it doesn't check for other
+ *       HTML errors and only closes tags usually not closed in HTML (`br`,
+ *       `hr` and `img`). In case of an error, debug builds will fail
+ *       on assertion, release builds will silently stop at the first error
  *
  * \sa
  * https://matrix.org/docs/spec/client_server/latest#m-room-message-msgtypes
  */
-QString filterQtHtmlToMatrix(const QString& html,
-                             QuaternionRoom* context = nullptr);
+
+QString qtToMatrix(const QString& html, QuaternionRoom* context = nullptr);
 
 /*! \brief Make the received HTML with Matrix attributes compatible with Qt
  *
- * This function also removes HTML tags disallowed in Matrix (same as
- * filterQtHtmlToMatrix) and cleans away extraneous HTML parts but does the
- * reverse conversion of Matrix-specific attributes to standard HTML that
- * Qt understands. As its counterpart, it requires at least the `body` element
- * to be there and assumes well-formed HTML, not recovering from missing
- * closing tags except those usually not closed in HTML (`br` etc.).
+ * Similar to qtToMatrix(), this function removes HTML tags disallowed in Matrix
+ * and cleans away extraneous HTML parts but it does the reverse conversion of
+ * Matrix-specific attributes to standard HTML that Qt understands. It can deal
+ * with a few more escaping errors compared to qtToMatrix(), but still
+ * doesn't recover from missing closing tags except those usually not closed
+ * in HTML (`br` etc.). In case of an irrecoverable error the returned structure
+ * will contain the error details (position and brief description), along with
+ * whatever HTML the function managed to produce before the failure.
  *
+ * \sa Result
  * \sa
  * https://matrix.org/docs/spec/client_server/latest#m-room-message-msgtypes
  */
-QString filterMatrixHtmlToQt(const QString& html,
-                             QuaternionRoom* context = nullptr);
+Result matrixToQt(const QString& html, QuaternionRoom* context = nullptr,
+                  ParsingMode parsingMode = Tolerant);
+
+}
+Q_DECLARE_METATYPE(HtmlFilter::Result)

--- a/client/htmlfilter.h
+++ b/client/htmlfilter.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <QString>
+#include <QtCore/QMetaType> // For Q_NAMESPACE and Q_DECLARE_METATYPE
+#include <QtCore/QString>
 
 class QuaternionRoom;
 

--- a/client/htmlfilter.h
+++ b/client/htmlfilter.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QString>
+
+class QuaternionRoom;
+
+/*! \brief Make the passed HTML compliant with Matrix requirements
+ *
+ * This function removes HTML tags disallowed in Matrix; on top of that,
+ * it cleans away extra parts (DTD, `head`, top-level `p`, extra `span`
+ * inside hyperlinks etc.) added by Qt when exporting QTextDocument
+ * to HTML, and converts some formatting accepted in Matrix to tags
+ * attributes allowed by the CS API spec. It requires at least a `<body>` pair
+ * of tags to be there and assumes well-formed HTML (i.e. it doesn't recover
+ * from missing closing tags, except `br`, `hr` and `img`).
+ *
+ * \sa
+ * https://matrix.org/docs/spec/client_server/latest#m-room-message-msgtypes
+ */
+QString filterQtHtmlToMatrix(const QString& html,
+                             QuaternionRoom* context = nullptr);
+
+/*! \brief Make the received HTML with Matrix attributes compatible with Qt
+ *
+ * This function also removes HTML tags disallowed in Matrix (same as
+ * filterQtHtmlToMatrix) and cleans away extraneous HTML parts but does the
+ * reverse conversion of Matrix-specific attributes to standard HTML that
+ * Qt understands. As its counterpart, it requires at least the `body` element
+ * to be there and assumes well-formed HTML, not recovering from missing
+ * closing tags except those usually not closed in HTML (`br` etc.).
+ *
+ * \sa
+ * https://matrix.org/docs/spec/client_server/latest#m-room-message-msgtypes
+ */
+QString filterMatrixHtmlToQt(const QString& html,
+                             QuaternionRoom* context = nullptr);

--- a/client/kchatedit.cpp
+++ b/client/kchatedit.cpp
@@ -165,9 +165,12 @@ int KChatEdit::maxHistorySize() const
     return d->maxHistorySize;
 }
 
-void KChatEdit::setMaxHistorySize(int maxHistorySize)
+void KChatEdit::setMaxHistorySize(int newMaxSize)
 {
-    d->maxHistorySize = maxHistorySize;
+    if (d->maxHistorySize != newMaxSize) {
+        d->maxHistorySize = newMaxSize;
+        emit maxHistorySizeChanged();
+    }
 }
 
 void KChatEdit::switchContext(QObject* contextKey)

--- a/client/kchatedit.cpp
+++ b/client/kchatedit.cpp
@@ -28,13 +28,13 @@ public:
     void updateAndMoveInHistory(int increment);
     void saveInput();
 
-    inline QTextDocument* makeDocument()
+    QTextDocument* makeDocument()
     {
         Q_ASSERT(contextKey);
         return new QTextDocument(contextKey);
     }
 
-    inline void setContext(QObject* newContextKey)
+    void setContext(QObject* newContextKey)
     {
         contextKey = newContextKey;
         auto& context = contexts[contextKey]; // Create if needed
@@ -45,17 +45,18 @@ public:
         if (history.isEmpty() || !history.last()->isEmpty())
             history.push_back(makeDocument());
 
-        while (history.size() > maxHistorySize) {
+        while (history.size() > maxHistorySize)
             delete history.takeFirst();
-        }
         index = history.size() - 1;
 
         // QTextDocuments are parented to the context object, so are destroyed
         // automatically along with it; but the hashmap should be cleaned up
         if (newContextKey != q)
-            q->connect(newContextKey, &QObject::destroyed, q,
-                       [this, newContextKey] { contexts.remove(newContextKey); });
-        Q_ASSERT(contexts.contains(newContextKey) && history.size() > 0);
+            QObject::connect(newContextKey, &QObject::destroyed, q,
+                             [this, newContextKey] {
+                                 contexts.remove(newContextKey);
+                             });
+        Q_ASSERT(contexts.contains(newContextKey) && !history.empty());
     }
 
     KChatEdit* q = nullptr;

--- a/client/kchatedit.cpp
+++ b/client/kchatedit.cpp
@@ -114,7 +114,8 @@ void KChatEdit::KChatEditPrivate::saveInput()
         emit q->savedInputChanged();
     } else if (input != getDocumentText(q->savedInput())) {
         // Insert a copy of the edited text just before the placeholder
-        history.insert(history.end() - 1, q->document()->clone(contextKey));
+        history.insert(history.end() - 1, q->document());
+        q->setDocument(makeDocument());
 
         if (history.size() >= maxHistorySize) {
             delete history.takeFirst();

--- a/client/kchatedit.h
+++ b/client/kchatedit.h
@@ -48,7 +48,7 @@ class KChatEdit : public QTextEdit
 {
     Q_OBJECT
     Q_PROPERTY(QTextDocument* savedInput READ savedInput NOTIFY savedInputChanged)
-    Q_PROPERTY(int maxHistorySize READ maxHistorySize WRITE setMaxHistorySize)
+    Q_PROPERTY(int maxHistorySize READ maxHistorySize WRITE setMaxHistorySize NOTIFY maxHistorySizeChanged)
 
 public:
     explicit KChatEdit(QWidget *parent = nullptr);
@@ -87,7 +87,7 @@ public:
      * Set the maximum number of input items that the history can store.
      * @see maxHistorySize()
      */
-    void setMaxHistorySize(int maxHistorySize);
+    void setMaxHistorySize(int newMaxSize);
 
     QSize minimumSizeHint() const Q_DECL_OVERRIDE;
     QSize sizeHint() const Q_DECL_OVERRIDE;
@@ -123,6 +123,8 @@ Q_SIGNALS:
 
     /** A new context has been selected */
     void contextSwitched();
+
+    void maxHistorySizeChanged();
 
 protected:
     void keyPressEvent(QKeyEvent *event) override;

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -23,6 +23,7 @@
 #include <QtQml> // for qmlRegisterType()
 
 #include "../quaternionroom.h"
+#include "../htmlfilter.h"
 #include <connection.h>
 #include <user.h>
 #include <settings.h>
@@ -432,12 +433,29 @@ QVariant MessageEventModel::data(const QModelIndex& idx, int role) const
         // clang-format off
         return visit(evt
             , [this] (const RoomMessageEvent& e) {
+                // clang-format on
                 using namespace MessageEventContent;
 
-                if (e.hasTextContent() && e.mimeType().name() != "text/plain")
-                    return static_cast<const TextContent*>(e.content())->body;
-                if (e.hasFileContent())
-                {
+                if (e.hasTextContent() && e.mimeType().name() != "text/plain") {
+                    // Naïvely assume that it's HTML
+                    auto htmlBody =
+                        static_cast<const TextContent*>(e.content())->body;
+                    const auto& result =
+                        HtmlFilter::matrixToQt(htmlBody, m_currentRoom);
+                    if (result.errorPos == -1) // The HTML is good enough
+                        return result.filteredHtml;
+                    // If HTML is bad (or it's not HTML at all), fall through
+                    // to returning the prettified plain text - leaving
+                    // a loophole to visualise HTML errors
+                    if (Settings().get("Debug/html", false))
+                        return QString(
+                            m_currentRoom->prettyPrint(e.plainBody())
+                            % QStringLiteral("<br /><font color=\"red\">At pos "
+                                             "%1: %2</font>")
+                                  .arg(QString::number(result.errorPos),
+                                       result.errorString));
+                }
+                if (e.hasFileContent()) {
                     auto fileCaption =
                         e.content()->fileInfo()->originalName.toHtmlEscaped();
                     if (fileCaption.isEmpty())
@@ -445,6 +463,7 @@ QVariant MessageEventModel::data(const QModelIndex& idx, int role) const
                     return !fileCaption.isEmpty() ? fileCaption : tr("a file");
                 }
                 return m_currentRoom->prettyPrint(e.plainBody());
+                // clang-format off
             }
             , [this] (const RoomMemberEvent& e) {
                 // clang-format on

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -265,7 +265,7 @@ QDateTime MessageEventModel::makeMessageTimestamp(
     return {};
 }
 
-QString MessageEventModel::renderDate(const QDateTime& timestamp) const
+QString MessageEventModel::renderDate(const QDateTime& timestamp)
 {
     auto date = timestamp.toLocalTime().date();
     static Quotient::SettingsGroup sg { "UI" };

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -69,7 +69,7 @@ class MessageEventModel: public QAbstractListModel
 
         int timelineBaseIndex() const;
         QDateTime makeMessageTimestamp(const QuaternionRoom::rev_iter_t& baseIt) const;
-        QString renderDate(const QDateTime& timestamp) const;
+        static QString renderDate(const QDateTime& timestamp);
         bool isUserActivityNotable(const QuaternionRoom::rev_iter_t& baseIt) const;
 
         void refreshLastUserEvents(int baseTimelineRow);


### PR DESCRIPTION
What started as an attempt to improve experience after #580 ended up being an attempt to add full-blown support of rich text in Quaternion - if not in UI then at least in the back-office. The result of this attempt is in this PR:
- Two new functions in `HtmlFilter` namespace, `qtToMatrix()` and `matrixToQt()` that can translate between Qt and Matrix subsets of HTML, taking into account quirks of each side (read: custom `data-` attributes in Matrix HTML and strong reliance on CSS in HTML produced by `QTextDocument`.
- The message entry box automatically produces actual hyperlinks when tab-completing nicknames.
- It also accepts arbitrary (in the part supported by Qt) rich text (either by drag-n-drop or by copy-paste), shows it and sends as a message (after converting to proper Matrix HTML as much as possible).
- `/html` command is now validating; before sending your HTML it will filter it, sending only [things endorsed by the spec](https://matrix.org/docs/spec/client_server/latest#m-room-message-msgtypes) and complaining about tags not endorsed or malformed HTML.
- `/md` command is available if Quaternion is built with Qt that supports Markdown (i.e., 5.14 or newer).

The main remaining thing is making the filter a bit more tolerant to mistakes and malformed pieces:
- [x] ~~There's no feedback occuring when HTML filtering cuts significant pieces from `/html` entry, including the malformed HTML case, in which the filter would just stop at the malformed position and return whatever it managed to produce by far. Quaternion then sends this thing to the wire, without the user ever having a chance to fix the problem (and we still don't have editing in Quaternion, so UX is really unforgiving).~~
- [x] ~~The code that actually transforms Matrix HTML (coming from the wire) to Qt HTML in order to display it in the timeline is not commited yet, partially for the same reason as above: as the filter is using Qt Core's XML parser (there's no reasonably complete/extensible HTML parser in Qt, aside from Qt WebEngine, that is), it is very picky about constructs it considers malformed XML. To feed HTML to it the messages get some pre-treatment and it works pretty well; but the filter still cuts messages short in some cases, especially around unescaped `>` and `<` characters. Moar testin' needed (which is why this PR is now being submitted and will be merged relatively soon).~~