### PR TITLE
Allow to mix Markdown and rich text

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,13 @@ Settings not exposed in UI:
   next paragraph); the default is true.
 - `hyperlink_users` - set this to false (or 0) if you do NOT want to
   hyperlink matrix user IDs in messages. By default it's true.
+- `auto_markdown` - since version 0.0.9.5, and only if built with Qt 5.14
+  or newer (builds for Windows at GitHub, as well as Flatpaks, use Qt 5.14),
+  setting this to `true` makes Quaternion parse all messages that you send
+  as Markdown, without having to prepend them with `/md` command. By default,
+  this is `false` now since it cannot be enabled in builds with older Qt and
+  since the whole functionality is experimental. If you have it enabled, feel
+  free to submit bug reports at the usual place.
 
 Since version 0.0.9.5, all Quaternion binaries at GitHub are compiled with
 Qt Keychain support. It means that Quaternion will try to store your access

--- a/client/htmlfilter.cpp
+++ b/client/htmlfilter.cpp
@@ -289,6 +289,7 @@ void Processor::runOn(QString html)
         }
         case QXmlStreamReader::Characters:
         case QXmlStreamReader::EntityReference: {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
             if (firstElement && mode.testFlag(ConvertMarkdown)) {
                 // Remove the line break Qt inserts after <body> because it
                 // confuses Markdown parser converting it to HTML line break.
@@ -297,6 +298,7 @@ void Processor::runOn(QString html)
                     continue; // Maintain firstElement
                 }
             }
+#endif
             // Outside of links, defer writing until the nearest tag (opening
             // or closing) in order to linkify the whole text piece with all
             // entity references resolved.
@@ -489,7 +491,6 @@ void Processor::filterText(QString& textBuffer)
     } else
 #endif
     {
-        Q_ASSERT(!mode.testFlag(ConvertMarkdown)); // Double-check for older Qt
         Quotient::linkifyUrls(textBuffer);
         textBuffer = "<body>" % textBuffer % "</body>";
     }

--- a/client/htmlfilter.h
+++ b/client/htmlfilter.h
@@ -8,9 +8,6 @@ class QuaternionRoom;
 namespace HtmlFilter {
 Q_NAMESPACE
 
-enum ParsingMode { Tolerant = 0, Validating = 1 };
-Q_ENUM_NS(ParsingMode)
-
 /*! \brief Result structure for Matrix HTML parsing
  *
  * This is the return type of matrixToQt(), which, unlike qtToMatrix(),
@@ -52,8 +49,11 @@ public:
  * \sa
  * https://matrix.org/docs/spec/client_server/latest#m-room-message-msgtypes
  */
-
 QString qtToMatrix(const QString& html, QuaternionRoom* context = nullptr);
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+QString mixedToMatrix(const QString& html, QuaternionRoom* context = nullptr);
+#endif
 
 /*! \brief Make the received HTML with Matrix attributes compatible with Qt
  *
@@ -66,12 +66,15 @@ QString qtToMatrix(const QString& html, QuaternionRoom* context = nullptr);
  * will contain the error details (position and brief description), along with
  * whatever HTML the function managed to produce before the failure.
  *
+ * \param matrixHtml text in Matrix HTML that should be converted to Qt HTML
+ * \param context optional room context to enrich the text
+ * \param validate whether the algorithm should stop at disallowed HTML tags
+ *                 rather than ignore them
  * \sa Result
  * \sa
  * https://matrix.org/docs/spec/client_server/latest#m-room-message-msgtypes
  */
-Result matrixToQt(const QString& html, QuaternionRoom* context = nullptr,
-                  ParsingMode parsingMode = Tolerant);
-
+Result matrixToQt(const QString& matrixHtml, QuaternionRoom* context = nullptr,
+                  bool validate = false);
 }
 Q_DECLARE_METATYPE(HtmlFilter::Result)


### PR DESCRIPTION
A new setting, `UI/auto_markdown`, is introduced to enable Markdown for all messages, even if `/md` command is not used. To suppress Markdown parsing for a given message there's `/plain` command now.

Closes #421.