### PR TITLE
New read marker

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -76,8 +76,10 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
             "User objects can only be created by libQuotient");
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         qmlRegisterAnonymousType<GetRoomEventsJob>("Quotient", 1);
+        qmlRegisterAnonymousType<MessageEventModel>("Quotient", 1);
 #else
         qmlRegisterType<GetRoomEventsJob>();
+        qmlRegisterType<MessageEventModel>();
 #endif
         qRegisterMetaType<GetRoomEventsJob*>("GetRoomEventsJob*");
         qRegisterMetaType<User*>("User*");

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -51,7 +51,6 @@ QHash<int, QByteArray> MessageEventModel::roleNames() const
         roles.insert(ContentRole, "content");
         roles.insert(ContentTypeRole, "contentType");
         roles.insert(HighlightRole, "highlight");
-        roles.insert(ReadMarkerRole, "readMarker");
         roles.insert(SpecialMarksRole, "marks");
         roles.insert(LongOperationRole, "progressInfo");
         roles.insert(AnnotationRole, "annotation");
@@ -92,8 +91,6 @@ void MessageEventModel::changeRoom(QuaternionRoom* room)
     m_currentRoom = room;
     if( room )
     {
-        lastReadEventId = room->readMarkerEventId();
-
         using namespace Quotient;
         connect(m_currentRoom, &Room::aboutToAddNewMessages, this,
                 [=](RoomEventsRange events)
@@ -150,9 +147,6 @@ void MessageEventModel::changeRoom(QuaternionRoom* room)
                     }
                     refreshRow(timelineBaseIndex()); // Refresh the looks
                     refreshLastUserEvents(0);
-                    if (m_currentRoom->timelineSize() > 1) // Refresh above
-                        refreshEventRoles(timelineBaseIndex() + 1,
-                                          {ReadMarkerRole});
                     if (timelineBaseIndex() > 0) // Refresh below, see #312
                         refreshEventRoles(timelineBaseIndex() - 1,
                                           {AboveAuthorRole, AboveSectionRole});
@@ -164,13 +158,7 @@ void MessageEventModel::changeRoom(QuaternionRoom* room)
         connect(m_currentRoom, &Room::pendingEventDiscarded,
                 this, &MessageEventModel::endRemoveRows);
         connect(m_currentRoom, &Room::readMarkerMoved,
-            this, [this] {
-            refreshEventRoles(
-                std::exchange(lastReadEventId,
-                              m_currentRoom->readMarkerEventId()),
-                {ReadMarkerRole});
-            refreshEventRoles(lastReadEventId, {ReadMarkerRole});
-        });
+                this, &MessageEventModel::readMarkerUpdated);
         connect(m_currentRoom, &Room::replacedEvent, this,
                 [this] (const RoomEvent* newEvent) {
                     refreshLastUserEvents(
@@ -188,19 +176,33 @@ void MessageEventModel::changeRoom(QuaternionRoom* room)
                 this, &MessageEventModel::refreshEvent);
         qDebug() << "Connected to room" << room->objectName()
                  << "as" << room->localUser()->id();
-    } else
-        lastReadEventId.clear();
+    }
     endResetModel();
+    emit readMarkerUpdated();
 }
 
 int MessageEventModel::refreshEvent(const QString& eventId)
 {
-    return refreshEventRoles(eventId);
+    int row = findRow(eventId);
+    if (row >= 0)
+        refreshEventRoles(row);
+    else
+        qWarning() << "Trying to refresh inexistent event:" << eventId;
+    return row;
 }
 
 void MessageEventModel::refreshRow(int row)
 {
     refreshEventRoles(row);
+}
+
+int MessageEventModel::readMarkerVisualIndex() const
+{
+    if (!m_currentRoom)
+        return -1; // Beyond the bottommost (sync) edge of the timeline
+    if (auto r = findRow(m_currentRoom->readMarkerEventId()); r != -1)
+        return r;
+    return rowCount(); // Beyond the topmost (history) edge of the timeline
 }
 
 int MessageEventModel::timelineBaseIndex() const
@@ -219,27 +221,18 @@ int MessageEventModel::findRow(const QString& id) const
     // On 64-bit platforms, difference_type for std containers is long long
     // but Qt uses int throughout its interfaces; hence casting to int below.
     int row = -1;
-    // First try pendingEvents because it is almost always very short.
-    const auto pendingIt = m_currentRoom->findPendingEvent(id);
-    if (pendingIt != m_currentRoom->pendingEvents().end())
-        row = int(pendingIt - m_currentRoom->pendingEvents().begin());
-    else {
-        const auto timelineIt = m_currentRoom->findInTimeline(id);
-        if (timelineIt != m_currentRoom->timelineEdge())
-            row = int(timelineIt - m_currentRoom->messageEvents().rbegin())
-                    + timelineBaseIndex();
+    if (!id.isEmpty()) {
+        // First try pendingEvents because it is almost always very short.
+        const auto pendingIt = m_currentRoom->findPendingEvent(id);
+        if (pendingIt != m_currentRoom->pendingEvents().end())
+            row = int(pendingIt - m_currentRoom->pendingEvents().begin());
+        else {
+            const auto timelineIt = m_currentRoom->findInTimeline(id);
+            if (timelineIt != m_currentRoom->timelineEdge())
+                row = int(timelineIt - m_currentRoom->messageEvents().rbegin())
+                        + timelineBaseIndex();
+        }
     }
-    return row;
-}
-
-int MessageEventModel::refreshEventRoles(const QString& id,
-                                         const QVector<int>& roles)
-{
-    int row = findRow(id);
-    if (row >= 0)
-        refreshEventRoles(row, roles);
-    else
-        qWarning() << "Trying to refresh inexistent event:" << id;
     return row;
 }
 
@@ -681,9 +674,6 @@ QVariant MessageEventModel::data(const QModelIndex& idx, int role) const
 
     if( role == HighlightRole )
         return m_currentRoom->isEventHighlighted(&evt);
-
-    if (role == ReadMarkerRole)
-        return evt.id() == lastReadEventId;
 
     if( role == SpecialMarksRole )
     {

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -55,7 +55,7 @@ class MessageEventModel: public QAbstractListModel
         int rowCount(const QModelIndex& parent = QModelIndex()) const override;
         QVariant data(const QModelIndex& idx, int role = Qt::DisplayRole) const override;
         QHash<int, QByteArray> roleNames() const override;
-        int findRow(const QString& id) const;
+        int findRow(const QString& id, bool includePending = false) const;
 
     signals:
         /// This is different from Room::readMarkerMoved() in that it is also

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -26,6 +26,7 @@
 class MessageEventModel: public QAbstractListModel
 {
         Q_OBJECT
+        Q_PROPERTY(int readMarkerVisualIndex READ readMarkerVisualIndex NOTIFY readMarkerUpdated)
     public:
         enum EventRoles {
             EventTypeRole = Qt::UserRole + 1,
@@ -38,7 +39,6 @@ class MessageEventModel: public QAbstractListModel
             ContentRole,
             ContentTypeRole,
             HighlightRole,
-            ReadMarkerRole,
             SpecialMarksRole,
             LongOperationRole,
             AnnotationRole,
@@ -57,13 +57,18 @@ class MessageEventModel: public QAbstractListModel
         QHash<int, QByteArray> roleNames() const override;
         int findRow(const QString& id) const;
 
+    signals:
+        /// This is different from Room::readMarkerMoved() in that it is also
+        /// emitted when the room or the last read event is first shown
+        void readMarkerUpdated();
+
     private slots:
         int refreshEvent(const QString& eventId);
         void refreshRow(int row);
 
     private:
         QuaternionRoom* m_currentRoom = nullptr;
-        QString lastReadEventId;
+        int readMarkerVisualIndex() const;
         int rowBelowInserted = -1;
         bool movingEvent = false;
 
@@ -74,5 +79,4 @@ class MessageEventModel: public QAbstractListModel
 
         void refreshLastUserEvents(int baseTimelineRow);
         void refreshEventRoles(int row, const QVector<int>& roles = {});
-        int refreshEventRoles(const QString& id, const QVector<int>& roles = {});
 };


### PR DESCRIPTION
Key changes:
- The read marker is rendered on top of the whole timeline, rather than a single event. This allowed to animate shifts from event to event in a more natural way, and also give a visual hint whether the user's scrolling over unread vs. read events.
- `ListView` doesn't position events if they don't take space on the screen (size of 0 on either dimension); so even with the point above, if the read marker is on an edit or a reaction, or a state event hidden by configuration (joins/leaves, e.g.), it's still not shown. Therefore, to fix #687, the event model shifts the read marker index to the "latest" non-hidden event before the read marker, and this is used to render the read marker line.