### PR TITLE
clip the content of room topic inside the scroll view

### DIFF
--- a/client/qml/Timeline.qml
+++ b/client/qml/Timeline.qml
@@ -147,6 +147,7 @@ Rectangle {
                 width: parent.width
                 height: Math.min(topicText.contentHeight,
                                  room ? root.height / 5 : 0)
+                clip: true
 
                 ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
                 ScrollBar.vertical.policy: ScrollBar.AsNeeded


### PR DESCRIPTION
otherwise a suffuciently long topic text could expand into the chatView area and
make it unreadable