### PR TITLE
Desktop icon installation/AppImage cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,7 @@ if(LINUX)
             DESTINATION ${CMAKE_INSTALL_DATADIR}/Quotient/quaternion/translations
             )
     file(GLOB quaternion_icons icons/quaternion/*-apps-quaternion.png)
-    ecm_install_icons(ICONS ${quaternion_icons} icons/quaternion/sc-apps-quaternion.svgz
+    ecm_install_icons(ICONS ${quaternion_icons} icons/quaternion/sources/quaternion.svg
                       DESTINATION ${CMAKE_INSTALL_DATADIR}/icons
                       )
 endif(LINUX)


### PR DESCRIPTION
The original problem was that linuxdeploy could sporadically fail to produce an AppImage, [stumbling over an svgz file](https://github.com/linuxdeploy/linuxdeploy/issues/168) installed to `/usr/share/icons/hicolor/scalable/apps`. On the other hand, Icon Naming Spec does not recognise svgz as a valid icon extension/format, which makes a case for switching to plain svg instead of svgz.