### PR TITLE
CI: use Flatpak spin of AppStream validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         fi
         sudo apt-get -qq install ninja-build $EXTRA_DEPS
         if [[ "$VALIDATE_APPSTREAM" == 'true' ]]; then
-          flatpak install --user -y org.freedesktop.appstream-glib
+          flatpak install --user -y https://flathub.org/repo/appstream/org.freedesktop.appstream-glib.flatpakref
         fi
 
     - name: Install Ninja (macOS/Windows)


### PR DESCRIPTION
The Flatpak version of appstream-glib alters the behaviour of the `appstream-util validate` quite a bit, with the ultimate result being somewhere between the original `validate` and `validate-relax` subcommands. Since the validation here is mainly aimed at fulfilling Flathub's requirements, and Flathub itself uses `org.freedesktop.appstream-glib` to validate AppStream files, it's only natural to use the same here in CI.