### PR TITLE
TimelineTextEditSelector: enable preventStealing

### DIFF
--- a/client/qml/TimelineTextEditSelector.qml
+++ b/client/qml/TimelineTextEditSelector.qml
@@ -10,6 +10,7 @@ MouseArea {
 
     anchors.fill: parent
     acceptedButtons: Qt.LeftButton
+    preventStealing: true
 
     onPressed: {
         var x = mouse.x


### PR DESCRIPTION
Event stealing cannot be allowed because current text selection gestures conflict with flickable gestures.