### PR TITLE
TimelineTextEditSelector: fix selection extension

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -830,8 +830,3 @@ void ChatRoomWidget::textDrop(const QString& text)
 {
     m_chatEdit->insertPlainText(text);
 }
-
-Qt::KeyboardModifiers ChatRoomWidget::getModifierKeys() const
-{
-    return QGuiApplication::keyboardModifiers();
-}

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -49,7 +49,6 @@ class ChatRoomWidget : public QWidget
         TimelineWidget* timelineWidget() const;
 
         completions_t findCompletionMatches(const QString& pattern) const;
-        Q_INVOKABLE Qt::KeyboardModifiers getModifierKeys() const;
 
     public slots:
         void setRoom(QuaternionRoom* newRoom);

--- a/client/timelinewidget.cpp
+++ b/client/timelinewidget.cpp
@@ -338,3 +338,8 @@ bool TimelineWidget::pendingMarkRead() const
     const auto rm = currentRoom()->fullyReadMarker();
     return rm != currentRoom()->historyEdge() && rm->index() < indexToMaybeRead;
 }
+
+Qt::KeyboardModifiers TimelineWidget::getModifierKeys() const
+{
+    return QGuiApplication::keyboardModifiers();
+}

--- a/client/timelinewidget.h
+++ b/client/timelinewidget.h
@@ -19,6 +19,7 @@ public:
     ~TimelineWidget() override;
     QString selectedText() const;
     QuaternionRoom* currentRoom() const;
+    Q_INVOKABLE Qt::KeyboardModifiers getModifierKeys() const;
 
 signals:
     void resourceRequested(const QString& idOrUri, const QString& action = {});


### PR DESCRIPTION
Extension of current selection by shift+click was broken due to
this method wasn't brought to the right class when `TimelineWidget`
was factored out of `ChatRoomWidget`.

Error message:
`qrc:/qml/TimelineTextEditSelector.qml:23: TypeError: Property 'getModifierKeys' of object TimelineWidget(0x24026c0) is not a function`