### PR TITLE
Chatedit: make default paste mode configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ Settings not exposed in UI:
   is `false` since the current support of Markdown by Qt is buggy, and the whole
   functionality in Quaternion is, again, experimental. If you have it enabled
   (or use `/md` command) feel free to submit bug reports at the usual place.
+- `paste_plaintext_by_default` - set this to false (or 0) if you want to paste
+  formatted text by default.
 
 Since version 0.0.95, all Quaternion binaries at GitHub Releases are compiled
 with Qt Keychain support. It means that Quaternion will try to store your access

--- a/client/chatedit.cpp
+++ b/client/chatedit.cpp
@@ -77,8 +77,8 @@ void ChatEdit::contextMenuEvent(QContextMenuEvent *event)
     menu->addAction(action);
 
     action = new QAction(QIcon::fromTheme("edit-paste"),
-                         tr(pastePlaintextByDefault() ? "Paste as rich text"
-                                                      : "Paste as plain text"),
+                         pastePlaintextByDefault() ? tr("Paste as rich text")
+                                                   : tr("Paste as plain text"),
                          this);
     action->setShortcut(AlternatePasteShortcut);
     connect(action, &QAction::triggered, this, &ChatEdit::alternatePaste);

--- a/client/chatedit.cpp
+++ b/client/chatedit.cpp
@@ -37,13 +37,19 @@
 #include <util.h>
 
 static const QKeySequence ResetFormatShortcut("Ctrl+M");
+static const QKeySequence AlternatePasteShortcut("Ctrl+Shift+V");
 
 ChatEdit::ChatEdit(ChatRoomWidget* c)
     : KChatEdit(c), chatRoomWidget(c), matchesListPosition(0)
+    , m_pastePlaintext(pastePlaintextByDefault())
 {
     auto* sh = new QShortcut(this);
     sh->setKey(ResetFormatShortcut);
     connect(sh, &QShortcut::activated, this, &KChatEdit::resetCurrentFormat);
+
+    sh = new QShortcut(this);
+    sh->setKey(AlternatePasteShortcut);
+    connect(sh, &QShortcut::activated, this, &ChatEdit::alternatePaste);
 }
 
 void ChatEdit::keyPressEvent(QKeyEvent* event)
@@ -70,6 +76,22 @@ void ChatEdit::contextMenuEvent(QContextMenuEvent *event)
     connect(action, &QAction::triggered, this, &KChatEdit::resetCurrentFormat);
     menu->addAction(action);
 
+    action = new QAction(QIcon::fromTheme("edit-paste"),
+                         tr(pastePlaintextByDefault() ? "Paste as rich text"
+                                                      : "Paste as plain text"),
+                         this);
+    action->setShortcut(AlternatePasteShortcut);
+    connect(action, &QAction::triggered, this, &ChatEdit::alternatePaste);
+    bool insert = false;
+    for (QAction* a: menu->actions()) {
+        if (insert) {
+            menu->insertAction(a, action);
+            break;
+        }
+        if (a->objectName() == QStringLiteral("edit-paste"))
+            insert = true;
+    }
+
     menu->setAttribute(Qt::WA_DeleteOnClose);
     menu->popup(event->globalPos());
 }
@@ -85,6 +107,13 @@ bool ChatEdit::canInsertFromMimeData(const QMimeData *source) const
     return source->hasImage() || KChatEdit::canInsertFromMimeData(source);
 }
 
+void ChatEdit::alternatePaste()
+{
+    m_pastePlaintext = !pastePlaintextByDefault();
+    paste();
+    m_pastePlaintext = pastePlaintextByDefault();
+}
+
 void ChatEdit::insertFromMimeData(const QMimeData *source)
 {
     if (!source) {
@@ -93,19 +122,25 @@ void ChatEdit::insertFromMimeData(const QMimeData *source)
     }
 
     if (source->hasHtml()) {
-        // Before insertion, remove formatting unsupported in Matrix
-        const auto [cleanHtml, errorPos, errorString] =
-            HtmlFilter::fromLocalHtml(source->html());
-        if (errorPos != -1) {
-            qWarning() << "HTML insertion failed at pos" << errorPos
-                       << "with error" << errorString;
-            // FIXME: Come on... It should be app->showStatusMessage() or smth
-            emit chatRoomWidget->timelineWidget()->showStatusMessage(
-                tr("Could not insert HTML - it's either invalid or unsupported"),
-                5000);
-            return;
+        if (m_pastePlaintext) {
+            QTextDocument document;
+            document.setHtml(source->html());
+            insertPlainText(document.toPlainText());
+        } else {
+            // Before insertion, remove formatting unsupported in Matrix
+            const auto [cleanHtml, errorPos, errorString] =
+                HtmlFilter::fromLocalHtml(source->html());
+            if (errorPos != -1) {
+                qWarning() << "HTML insertion failed at pos" << errorPos
+                        << "with error" << errorString;
+                // FIXME: Come on... It should be app->showStatusMessage() or smth
+                emit chatRoomWidget->timelineWidget()->showStatusMessage(
+                    tr("Could not insert HTML - it's either invalid or unsupported"),
+                    5000);
+                return;
+            }
+            insertHtml(cleanHtml);
         }
-        insertHtml(cleanHtml);
         ensureCursorVisible();
     } else if (source->hasImage())
         emit insertImageRequested(source->imageData().value<QImage>());
@@ -271,4 +306,9 @@ void ChatEdit::insertMention(QString author, QUrl url)
         editCursor.insertText(postfix, textFormat);
     pickingMentions = true;
     cancelCompletion();
+}
+
+bool ChatEdit::pastePlaintextByDefault()
+{
+    return Quotient::Settings().get("UI/paste_plaintext_by_default", true);
 }

--- a/client/chatedit.h
+++ b/client/chatedit.h
@@ -41,6 +41,7 @@ class ChatEdit : public KChatEdit
 
     public slots:
         void switchContext(QObject* contextKey) override;
+        void alternatePaste();
 
     signals:
         void proposedCompletion(const QStringList& allCompletions, int curIndex);
@@ -61,6 +62,7 @@ class ChatEdit : public KChatEdit
         int matchesListPosition;
 
         bool pickingMentions = false;
+        bool m_pastePlaintext;
 
         /// \brief Initialise a new completion
         ///
@@ -71,6 +73,7 @@ class ChatEdit : public KChatEdit
                              QUrl mentionUrl, bool select);
         void keyPressEvent(QKeyEvent* event) override;
         void contextMenuEvent(QContextMenuEvent* event) override;
+        bool pastePlaintextByDefault();
 };
 
 


### PR DESCRIPTION
Many people like pasting plain text as there is less trouble with
it and does the job. Even Element pastes plain text by default
despite being a rich client. This is why this patch switches to
plain text pasting by default while makes it configurable.

Other version can be pasted by `Ctrl+Shift+V`.

Cc #849