### PR TITLE
RoomListModel: refresh room if highlights changed

### DIFF
--- a/client/models/roomlistmodel.cpp
+++ b/client/models/roomlistmodel.cpp
@@ -238,7 +238,7 @@ void RoomListModel::connectRoomSignals(Room* room)
     m_roomOrder->connectSignals(room);
     connect(room, &Room::changed, this, [this, room](Room::Changes changes) {
         using C = Room::Change;
-        if (changes & (C::Name | C::PartiallyReadStats | C::UnreadStats))
+        if (changes & (C::Name | C::PartiallyReadStats | C::UnreadStats | C::Highlights))
             refresh(room);
         else if (changes & C::Avatar)
             refresh(room, { Qt::DecorationRole });


### PR DESCRIPTION
`Room::Change::Highlights` was introduced in Quotient-0.7 and must be captured here because it changes model data.