### PR TITLE
Check for image MIME data before HTML data

### DIFF
--- a/client/chatedit.cpp
+++ b/client/chatedit.cpp
@@ -110,7 +110,9 @@ void ChatEdit::insertFromMimeData(const QMimeData *source)
         return;
     }
 
-    if (source->hasHtml()) {
+    if (source->hasImage())
+        emit insertImageRequested(source->imageData().value<QImage>());
+    else if (source->hasHtml()) {
         if (m_pastePlaintext) {
             QTextDocument document;
             document.setHtml(source->html());
@@ -131,9 +133,7 @@ void ChatEdit::insertFromMimeData(const QMimeData *source)
             insertHtml(cleanHtml);
         }
         ensureCursorVisible();
-    } else if (source->hasImage())
-        emit insertImageRequested(source->imageData().value<QImage>());
-    else if (source->hasUrls()) {
+    } else if (source->hasUrls()) {
         bool hasAnyProcessed = false;
         for (const QUrl &url : source->urls())
             if (url.isLocalFile()) {


### PR DESCRIPTION
Copying an image from Firefox attaches some HTML to the image. Extracting the plain text from the HTML before the image results in empty data in the field, with no image, triggering an assertion failure on message send.

This is a partial fix for issue #867.  Partial, because the resulting image does not appear in the chat window until relaunching, due to an error opening the temp file created by this.